### PR TITLE
feat: visualize daily goal progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Manage users, create accounts, and handle activation tokens.
   - Multi-language support (English and Ukrainian)
   - Configurable locale for date and time formatting (many regional variants)
   - Configurable start of week (any day of the week)
-  - Daily time goals with typical break planning
+  - Daily time goals with typical break planning and current-day progress visualization
   - Dark mode compatible UI
   - Remember me option for persistent login sessions
   - Self-service password change from profile page

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -265,9 +265,22 @@ tasks.register<Exec>("prettierFormat") {
     dependsOn("bunInstall")
 }
 
+tasks.register<Exec>("bunTest") {
+    description = "Run frontend unit tests with Bun"
+    group = "verification"
+    workingDir = file("frontend")
+    commandLine("bun", "test")
+    dependsOn("bunInstall")
+
+    inputs
+        .dir("frontend/src")
+        .withPropertyName("frontendSourceFiles")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+}
+
 // Make check task depend on prettier check
 tasks.named("check") {
-    dependsOn("prettierCheck")
+    dependsOn("prettierCheck", "bunTest")
 }
 
 // Combined formatting task

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,8 @@
     "build": "bun run build.ts",
     "dev": "bun run dev.ts",
     "format": "prettier --write .",
-    "format:check": "prettier --check ."
+    "format:check": "prettier --check .",
+    "test": "bun test"
   },
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.4",

--- a/frontend/src/components/time-logs/DailyGoalProgressBar.tsx
+++ b/frontend/src/components/time-logs/DailyGoalProgressBar.tsx
@@ -22,7 +22,12 @@ export function DailyGoalProgressBar({ entries, dailyGoal, locale }: DailyGoalPr
 
   if (!dailyGoal.enabled) return null;
 
-  const progress = calculateDailyGoalProgress(entries, dailyGoal.goalMinutes, dailyGoal.typicalBreaks, now);
+  const progress = calculateDailyGoalProgress({
+    entries,
+    goalMinutes: dailyGoal.goalMinutes,
+    typicalBreaks: dailyGoal.typicalBreaks,
+    now,
+  });
   if (!progress) return null;
 
   const estimatedCompletionTime = new Intl.DateTimeFormat(locale, {
@@ -52,11 +57,13 @@ export function DailyGoalProgressBar({ entries, dailyGoal, locale }: DailyGoalPr
         </TooltipTrigger>
         <TooltipContent data-testid="daily-goal-progress-tooltip">
           <div className="space-y-1">
-            <div>{t("timeLogs.dailyGoal.achievement", { percent: progress.progressPercent })}</div>
             {progress.progressPercent >= 100 ? (
               <div>{t("timeLogs.dailyGoal.met")}</div>
             ) : (
-              <div>{t("timeLogs.dailyGoal.estimatedCompletion", { time: estimatedCompletionTime })}</div>
+              <>
+                <div>{t("timeLogs.dailyGoal.achievement", { percent: progress.progressPercent })}</div>
+                <div>{t("timeLogs.dailyGoal.estimatedCompletion", { time: estimatedCompletionTime })}</div>
+              </>
             )}
           </div>
         </TooltipContent>

--- a/frontend/src/components/time-logs/DailyGoalProgressBar.tsx
+++ b/frontend/src/components/time-logs/DailyGoalProgressBar.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+import { calculateDailyGoalProgress } from "@/lib/daily-goal-progress";
+import type { DailyGoalSettings, TimeLogEntry } from "./types";
+
+interface DailyGoalProgressBarProps {
+  entries: TimeLogEntry[];
+  dailyGoal: DailyGoalSettings;
+  locale: string;
+}
+
+export function DailyGoalProgressBar({ entries, dailyGoal, locale }: DailyGoalProgressBarProps) {
+  const { t } = useTranslation();
+  const [now, setNow] = useState(() => new Date());
+
+  useEffect(() => {
+    setNow(new Date());
+    const interval = setInterval(() => setNow(new Date()), 60 * 1000);
+    return () => clearInterval(interval);
+  }, [entries, dailyGoal]);
+
+  if (!dailyGoal.enabled) return null;
+
+  const progress = calculateDailyGoalProgress(entries, dailyGoal.goalMinutes, dailyGoal.typicalBreaks, now);
+  if (!progress) return null;
+
+  const estimatedCompletionTime = new Intl.DateTimeFormat(locale, {
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(progress.estimatedCompletionTime);
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className="h-2 w-[clamp(50px,35vw,300px)] rounded-full bg-accent"
+            data-testid="daily-goal-progress"
+            role="progressbar"
+            tabIndex={0}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            aria-valuenow={progress.progressPercent}
+          >
+            <div
+              className="h-full rounded-full bg-accent-foreground transition-all"
+              style={{ width: `${progress.progressPercent}%` }}
+              data-testid="daily-goal-progress-fill"
+            />
+          </div>
+        </TooltipTrigger>
+        <TooltipContent data-testid="daily-goal-progress-tooltip">
+          <div className="space-y-1">
+            <div>{t("timeLogs.dailyGoal.achievement", { percent: progress.progressPercent })}</div>
+            {progress.progressPercent >= 100 ? (
+              <div>{t("timeLogs.dailyGoal.met")}</div>
+            ) : (
+              <div>{t("timeLogs.dailyGoal.estimatedCompletion", { time: estimatedCompletionTime })}</div>
+            )}
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/frontend/src/components/time-logs/DayGroup.tsx
+++ b/frontend/src/components/time-logs/DayGroup.tsx
@@ -3,18 +3,20 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { TimeEntry } from "./TimeEntry";
 import { GroupedTimeEntry } from "./GroupedTimeEntry";
 import { TotalDurationDisplay } from "./TotalDurationDisplay";
+import { DailyGoalProgressBar } from "./DailyGoalProgressBar";
 import { groupEntriesByTitleAndTags, isGroupedEntry } from "@/lib/entry-grouping";
 import { detectOverlaps } from "@/lib/overlap-detection";
-import type { DayGroup as DayGroupType } from "./types";
+import type { DailyGoalSettings, DayGroup as DayGroupType } from "./types";
 
 interface DayGroupProps {
   group: DayGroupType;
   locale: string;
   startOfWeek: number;
+  dailyGoal: DailyGoalSettings | null;
   onDataChange: () => Promise<void>;
 }
 
-export function DayGroup({ group, locale, startOfWeek, onDataChange }: DayGroupProps) {
+export function DayGroup({ group, locale, startOfWeek, dailyGoal, onDataChange }: DayGroupProps) {
   const { t } = useTranslation();
 
   // Detect overlaps within this day group
@@ -26,10 +28,13 @@ export function DayGroup({ group, locale, startOfWeek, onDataChange }: DayGroupP
   return (
     <Card className="border-none shadow-md" data-testid="day-group">
       <CardHeader className="pb-3">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <CardTitle className="text-lg text-foreground" data-testid="day-title">
             {group.displayTitle}
           </CardTitle>
+          {group.isToday && dailyGoal?.enabled && (
+            <DailyGoalProgressBar entries={group.entries} dailyGoal={dailyGoal} locale={locale} />
+          )}
           <div className="text-sm text-muted-foreground" data-testid="day-total-duration">
             {t("timeLogs.totalDuration")}: <TotalDurationDisplay entries={group.entries} />
           </div>

--- a/frontend/src/components/time-logs/DayGroups.tsx
+++ b/frontend/src/components/time-logs/DayGroups.tsx
@@ -3,17 +3,18 @@ import { useTranslation } from "react-i18next";
 import { DayGroup } from "./DayGroup";
 import { formatISODate, calculateDuration } from "@/lib/time-utils";
 import { formatDate } from "@/lib/date-format";
-import type { TimeLogEntry, DayGroup as DayGroupType } from "./types";
+import type { DailyGoalSettings, TimeLogEntry, DayGroup as DayGroupType } from "./types";
 
 interface DayGroupsProps {
   entries: TimeLogEntry[];
   activeEntry: TimeLogEntry | null;
   locale: string;
   startOfWeek: number;
+  dailyGoal: DailyGoalSettings | null;
   onDataChange: () => Promise<void>;
 }
 
-export function DayGroups({ entries, activeEntry, locale, startOfWeek, onDataChange }: DayGroupsProps) {
+export function DayGroups({ entries, activeEntry, locale, startOfWeek, dailyGoal, onDataChange }: DayGroupsProps) {
   const { t } = useTranslation();
   const [dayGroups, setDayGroups] = useState<DayGroupType[]>([]);
 
@@ -64,6 +65,7 @@ export function DayGroups({ entries, activeEntry, locale, startOfWeek, onDataCha
           displayTitle: getDayTitle(date, locale),
           entries: entries.sort((a, b) => new Date(b.startTime).getTime() - new Date(a.startTime).getTime()),
           totalDuration,
+          isToday: date === formatISODate(new Date()),
         };
       })
       .sort((a, b) => {
@@ -97,6 +99,7 @@ export function DayGroups({ entries, activeEntry, locale, startOfWeek, onDataCha
           group={group}
           locale={locale}
           startOfWeek={startOfWeek}
+          dailyGoal={dailyGoal}
           onDataChange={onDataChange}
         />
       ))}

--- a/frontend/src/components/time-logs/types.ts
+++ b/frontend/src/components/time-logs/types.ts
@@ -18,6 +18,16 @@ export interface DayGroup {
   displayTitle: string;
   entries: TimeLogEntry[];
   totalDuration: number;
+  isToday: boolean;
+}
+
+export interface DailyGoalSettings {
+  enabled: boolean;
+  goalMinutes: number;
+  typicalBreaks: {
+    from: string;
+    to: string;
+  }[];
 }
 
 /**

--- a/frontend/src/lib/daily-goal-progress.test.ts
+++ b/frontend/src/lib/daily-goal-progress.test.ts
@@ -20,11 +20,23 @@ function time(value: string): Date {
 
 describe("calculateDailyGoalProgress", () => {
   test("returns null for disabled or zero-minute goals", () => {
-    expect(calculateDailyGoalProgress([], 0, [], time("10:00"))).toBeNull();
+    expect(
+      calculateDailyGoalProgress({
+        entries: [],
+        goalMinutes: 0,
+        typicalBreaks: [],
+        now: time("10:00"),
+      })
+    ).toBeNull();
   });
 
   test("calculates progress and completion without breaks", () => {
-    const result = calculateDailyGoalProgress([entry("09:00", "10:30")], 180, [], time("11:00"));
+    const result = calculateDailyGoalProgress({
+      entries: [entry("09:00", "10:30")],
+      goalMinutes: 180,
+      typicalBreaks: [],
+      now: time("11:00"),
+    });
 
     expect(result?.totalMs).toBe(90 * 60 * 1000);
     expect(result?.progressPercent).toBe(50);
@@ -32,14 +44,24 @@ describe("calculateDailyGoalProgress", () => {
   });
 
   test("caps progress at 100 percent when the goal is exceeded", () => {
-    const result = calculateDailyGoalProgress([entry("09:00", "12:30")], 120, [], time("13:00"));
+    const result = calculateDailyGoalProgress({
+      entries: [entry("09:00", "12:30")],
+      goalMinutes: 120,
+      typicalBreaks: [],
+      now: time("13:00"),
+    });
 
     expect(result?.progressPercent).toBe(100);
     expect(result?.estimatedCompletionTime.toISOString()).toBe(time("13:00").toISOString());
   });
 
   test("uses now for active entries", () => {
-    const result = calculateDailyGoalProgress([entry("09:00", null)], 180, [], time("10:15"));
+    const result = calculateDailyGoalProgress({
+      entries: [entry("09:00", null)],
+      goalMinutes: 180,
+      typicalBreaks: [],
+      now: time("10:15"),
+    });
 
     expect(result?.totalMs).toBe(75 * 60 * 1000);
     expect(result?.progressPercent).toBe(41);
@@ -47,62 +69,62 @@ describe("calculateDailyGoalProgress", () => {
   });
 
   test("delays completion by a future break", () => {
-    const result = calculateDailyGoalProgress(
-      [entry("09:00", "10:00")],
-      180,
-      [{ from: "12:00", to: "12:30" }],
-      time("11:30")
-    );
+    const result = calculateDailyGoalProgress({
+      entries: [entry("09:00", "10:00")],
+      goalMinutes: 180,
+      typicalBreaks: [{ from: "12:00", to: "12:30" }],
+      now: time("11:30"),
+    });
 
     expect(result?.estimatedCompletionTime.toISOString()).toBe(time("14:00").toISOString());
   });
 
   test("starts after the current break when now is inside a break", () => {
-    const result = calculateDailyGoalProgress(
-      [entry("09:00", "10:00")],
-      120,
-      [{ from: "11:45", to: "12:15" }],
-      time("12:00")
-    );
+    const result = calculateDailyGoalProgress({
+      entries: [entry("09:00", "10:00")],
+      goalMinutes: 120,
+      typicalBreaks: [{ from: "11:45", to: "12:15" }],
+      now: time("12:00"),
+    });
 
     expect(result?.estimatedCompletionTime.toISOString()).toBe(time("13:15").toISOString());
   });
 
   test("skips multiple breaks in chronological order", () => {
-    const result = calculateDailyGoalProgress(
-      [entry("09:00", "10:00")],
-      240,
-      [
+    const result = calculateDailyGoalProgress({
+      entries: [entry("09:00", "10:00")],
+      goalMinutes: 240,
+      typicalBreaks: [
         { from: "14:00", to: "14:15" },
         { from: "12:00", to: "12:30" },
       ],
-      time("11:30")
-    );
+      now: time("11:30"),
+    });
 
     expect(result?.estimatedCompletionTime.toISOString()).toBe(time("15:15").toISOString());
   });
 
   test("ignores breaks that have already ended", () => {
-    const result = calculateDailyGoalProgress(
-      [entry("09:00", "10:00")],
-      120,
-      [{ from: "12:00", to: "12:30" }],
-      time("13:00")
-    );
+    const result = calculateDailyGoalProgress({
+      entries: [entry("09:00", "10:00")],
+      goalMinutes: 120,
+      typicalBreaks: [{ from: "12:00", to: "12:30" }],
+      now: time("13:00"),
+    });
 
     expect(result?.estimatedCompletionTime.toISOString()).toBe(time("14:00").toISOString());
   });
 
   test("ignores invalid break windows", () => {
-    const result = calculateDailyGoalProgress(
-      [entry("09:00", "10:00")],
-      120,
-      [
+    const result = calculateDailyGoalProgress({
+      entries: [entry("09:00", "10:00")],
+      goalMinutes: 120,
+      typicalBreaks: [
         { from: "bad", to: "12:00" },
         { from: "13:00", to: "12:00" },
       ],
-      time("11:00")
-    );
+      now: time("11:00"),
+    });
 
     expect(result?.estimatedCompletionTime.toISOString()).toBe(time("12:00").toISOString());
   });

--- a/frontend/src/lib/daily-goal-progress.test.ts
+++ b/frontend/src/lib/daily-goal-progress.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from "bun:test";
+import { calculateDailyGoalProgress } from "./daily-goal-progress";
+import type { TimeLogEntry } from "../components/time-logs/types";
+
+function entry(start: string, end: string | null, id = 1): TimeLogEntry {
+  return {
+    id,
+    startTime: time(start).toISOString(),
+    endTime: end ? time(end).toISOString() : null,
+    title: "Task",
+    ownerId: 1,
+    tags: [],
+  };
+}
+
+function time(value: string): Date {
+  const [hours, minutes] = value.split(":").map(Number);
+  return new Date(2024, 2, 16, hours, minutes, 0, 0);
+}
+
+describe("calculateDailyGoalProgress", () => {
+  test("returns null for disabled or zero-minute goals", () => {
+    expect(calculateDailyGoalProgress([], 0, [], time("10:00"))).toBeNull();
+  });
+
+  test("calculates progress and completion without breaks", () => {
+    const result = calculateDailyGoalProgress([entry("09:00", "10:30")], 180, [], time("11:00"));
+
+    expect(result?.totalMs).toBe(90 * 60 * 1000);
+    expect(result?.progressPercent).toBe(50);
+    expect(result?.estimatedCompletionTime.toISOString()).toBe(time("12:30").toISOString());
+  });
+
+  test("caps progress at 100 percent when the goal is exceeded", () => {
+    const result = calculateDailyGoalProgress([entry("09:00", "12:30")], 120, [], time("13:00"));
+
+    expect(result?.progressPercent).toBe(100);
+    expect(result?.estimatedCompletionTime.toISOString()).toBe(time("13:00").toISOString());
+  });
+
+  test("uses now for active entries", () => {
+    const result = calculateDailyGoalProgress([entry("09:00", null)], 180, [], time("10:15"));
+
+    expect(result?.totalMs).toBe(75 * 60 * 1000);
+    expect(result?.progressPercent).toBe(41);
+    expect(result?.estimatedCompletionTime.toISOString()).toBe(time("12:00").toISOString());
+  });
+
+  test("delays completion by a future break", () => {
+    const result = calculateDailyGoalProgress(
+      [entry("09:00", "10:00")],
+      180,
+      [{ from: "12:00", to: "12:30" }],
+      time("11:30")
+    );
+
+    expect(result?.estimatedCompletionTime.toISOString()).toBe(time("14:00").toISOString());
+  });
+
+  test("starts after the current break when now is inside a break", () => {
+    const result = calculateDailyGoalProgress(
+      [entry("09:00", "10:00")],
+      120,
+      [{ from: "11:45", to: "12:15" }],
+      time("12:00")
+    );
+
+    expect(result?.estimatedCompletionTime.toISOString()).toBe(time("13:15").toISOString());
+  });
+
+  test("skips multiple breaks in chronological order", () => {
+    const result = calculateDailyGoalProgress(
+      [entry("09:00", "10:00")],
+      240,
+      [
+        { from: "14:00", to: "14:15" },
+        { from: "12:00", to: "12:30" },
+      ],
+      time("11:30")
+    );
+
+    expect(result?.estimatedCompletionTime.toISOString()).toBe(time("15:15").toISOString());
+  });
+
+  test("ignores breaks that have already ended", () => {
+    const result = calculateDailyGoalProgress(
+      [entry("09:00", "10:00")],
+      120,
+      [{ from: "12:00", to: "12:30" }],
+      time("13:00")
+    );
+
+    expect(result?.estimatedCompletionTime.toISOString()).toBe(time("14:00").toISOString());
+  });
+
+  test("ignores invalid break windows", () => {
+    const result = calculateDailyGoalProgress(
+      [entry("09:00", "10:00")],
+      120,
+      [
+        { from: "bad", to: "12:00" },
+        { from: "13:00", to: "12:00" },
+      ],
+      time("11:00")
+    );
+
+    expect(result?.estimatedCompletionTime.toISOString()).toBe(time("12:00").toISOString());
+  });
+});

--- a/frontend/src/lib/daily-goal-progress.ts
+++ b/frontend/src/lib/daily-goal-progress.ts
@@ -11,14 +11,21 @@ export interface DailyGoalProgress {
   estimatedCompletionTime: Date;
 }
 
+export interface CalculateDailyGoalProgressArgs {
+  entries: TimeLogEntry[];
+  goalMinutes: number;
+  typicalBreaks: DailyGoalBreak[];
+  now: Date;
+}
+
 const MINUTE_MS = 60 * 1000;
 
-export function calculateDailyGoalProgress(
-  entries: TimeLogEntry[],
-  goalMinutes: number,
-  typicalBreaks: DailyGoalBreak[],
-  now: Date
-): DailyGoalProgress | null {
+export function calculateDailyGoalProgress({
+  entries,
+  goalMinutes,
+  typicalBreaks,
+  now,
+}: CalculateDailyGoalProgressArgs): DailyGoalProgress | null {
   if (goalMinutes <= 0) return null;
 
   const totalMs = entries.reduce((sum, entry) => sum + calculateEntryDuration(entry, now), 0);

--- a/frontend/src/lib/daily-goal-progress.ts
+++ b/frontend/src/lib/daily-goal-progress.ts
@@ -1,0 +1,94 @@
+import type { TimeLogEntry } from "../components/time-logs/types";
+
+export interface DailyGoalBreak {
+  from: string;
+  to: string;
+}
+
+export interface DailyGoalProgress {
+  totalMs: number;
+  progressPercent: number;
+  estimatedCompletionTime: Date;
+}
+
+const MINUTE_MS = 60 * 1000;
+
+export function calculateDailyGoalProgress(
+  entries: TimeLogEntry[],
+  goalMinutes: number,
+  typicalBreaks: DailyGoalBreak[],
+  now: Date
+): DailyGoalProgress | null {
+  if (goalMinutes <= 0) return null;
+
+  const totalMs = entries.reduce((sum, entry) => sum + calculateEntryDuration(entry, now), 0);
+  const goalMs = goalMinutes * MINUTE_MS;
+  const remainingMs = Math.max(0, goalMs - totalMs);
+
+  return {
+    totalMs,
+    progressPercent: Math.min(100, Math.floor((totalMs / goalMs) * 100)),
+    estimatedCompletionTime: addWorkingTime(now, remainingMs, typicalBreaks),
+  };
+}
+
+function calculateEntryDuration(entry: TimeLogEntry, now: Date): number {
+  const start = new Date(entry.startTime).getTime();
+  const end = entry.endTime ? new Date(entry.endTime).getTime() : now.getTime();
+  return Math.max(0, end - start);
+}
+
+function addWorkingTime(start: Date, durationMs: number, typicalBreaks: DailyGoalBreak[]): Date {
+  let cursor = new Date(start);
+  let remainingMs = durationMs;
+
+  while (remainingMs > 0) {
+    const nextBreak = getNextBreak(cursor, typicalBreaks);
+
+    if (!nextBreak) {
+      return new Date(cursor.getTime() + remainingMs);
+    }
+
+    if (cursor < nextBreak.from) {
+      const workUntilBreakMs = nextBreak.from.getTime() - cursor.getTime();
+      if (remainingMs <= workUntilBreakMs) {
+        return new Date(cursor.getTime() + remainingMs);
+      }
+      remainingMs -= workUntilBreakMs;
+      cursor = new Date(nextBreak.to);
+    } else if (cursor < nextBreak.to) {
+      cursor = new Date(nextBreak.to);
+    }
+  }
+
+  return cursor;
+}
+
+function getNextBreak(cursor: Date, typicalBreaks: DailyGoalBreak[]): { from: Date; to: Date } | null {
+  return (
+    typicalBreaks
+      .map((typicalBreak) => toBreakPeriod(cursor, typicalBreak))
+      .filter((period): period is { from: Date; to: Date } => period != null && period.to > cursor)
+      .sort((a, b) => a.from.getTime() - b.from.getTime())[0] ?? null
+  );
+}
+
+function toBreakPeriod(day: Date, typicalBreak: DailyGoalBreak): { from: Date; to: Date } | null {
+  const from = parseLocalTime(day, typicalBreak.from);
+  const to = parseLocalTime(day, typicalBreak.to);
+  if (!from || !to || to <= from) return null;
+  return { from, to };
+}
+
+function parseLocalTime(day: Date, value: string): Date | null {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value);
+  if (!match) return null;
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (hours > 23 || minutes > 59) return null;
+
+  const date = new Date(day);
+  date.setHours(hours, minutes, 0, 0);
+  return date;
+}

--- a/frontend/src/lib/i18n.ts
+++ b/frontend/src/lib/i18n.ts
@@ -229,6 +229,11 @@ const resources = {
         duration: "Duration",
         totalDuration: "Total",
         weeklyTotal: "Weekly total",
+        dailyGoal: {
+          achievement: "Goal achievement: {{percent}}%",
+          estimatedCompletion: "Estimated completion: {{time}}",
+          met: "Daily goal met",
+        },
         inProgress: "in progress",
         differentDayWarning: "This entry finishes on another day - {{date}}",
         overlapWarning: "This entry overlaps with '{{title}}'",
@@ -669,6 +674,11 @@ const resources = {
         duration: "Тривалість",
         totalDuration: "Всього",
         weeklyTotal: "Всього за тиждень",
+        dailyGoal: {
+          achievement: "Досягнення цілі: {{percent}}%",
+          estimatedCompletion: "Орієнтовне завершення: {{time}}",
+          met: "Денну ціль досягнуто",
+        },
         inProgress: "виконується",
         differentDayWarning: "Цей запис закінчується в інший день - {{date}}",
         overlapWarning: "Цей запис перетинається з '{{title}}'",

--- a/frontend/src/pages/TimeLogsPage.tsx
+++ b/frontend/src/pages/TimeLogsPage.tsx
@@ -10,7 +10,11 @@ import { apiGet } from "@/lib/api";
 import { weekDayToNumber } from "@/lib/time-utils";
 import { useDocumentTitle } from "@/hooks/useDocumentTitle";
 import { useTimeLogEntryEvents } from "@/hooks/useTimeLogEntryEvents";
-import type { TimeEntry, TimeLogEntry } from "@/components/time-logs/types";
+import type { DailyGoalSettings, TimeEntry, TimeLogEntry } from "@/components/time-logs/types";
+
+interface GoalsSettingsResponse {
+  dailyGoal: DailyGoalSettings;
+}
 
 export function TimeLogsPage() {
   const { t, i18n } = useTranslation();
@@ -20,6 +24,7 @@ export function TimeLogsPage() {
   const [error, setError] = useState<string | null>(null);
   const [userLocale, setUserLocale] = useState<string | null>(null);
   const [startOfWeek, setStartOfWeek] = useState<number>(1); // Default to Monday
+  const [dailyGoal, setDailyGoal] = useState<DailyGoalSettings | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
   const isInitialLoadRef = useRef(true);
 
@@ -117,13 +122,23 @@ export function TimeLogsPage() {
   // Load user's locale and start of week preference on mount
   useEffect(() => {
     async function loadUserProfile() {
-      const profile = await apiGet<{ locale: string; startOfWeek: string }>("/api-ui/users/profile");
+      const [profile, goalsSettings] = await Promise.all([
+        apiGet<{ locale: string; startOfWeek: string }>("/api-ui/users/profile"),
+        apiGet<GoalsSettingsResponse>("/api-ui/users/goals-settings"),
+      ]);
       setUserLocale(profile.locale);
       const startOfWeekNum = weekDayToNumber(profile.startOfWeek);
       setStartOfWeek(startOfWeekNum);
+      setDailyGoal({
+        ...goalsSettings.dailyGoal,
+        typicalBreaks: goalsSettings.dailyGoal.typicalBreaks ?? [],
+      });
     }
-    loadUserProfile();
-  }, []);
+    loadUserProfile().catch((err: any) => {
+      const errorCode = err.errorCode;
+      setError(errorCode ? t(`errorCodes.${errorCode}`) : err.message || t("common.error"));
+    });
+  }, [t]);
 
   // Don't render page elements until we have the user locale
   if (!userLocale) {
@@ -183,6 +198,7 @@ export function TimeLogsPage() {
               activeEntry={activeEntry}
               locale={locale}
               startOfWeek={startOfWeek}
+              dailyGoal={dailyGoal}
               onDataChange={loadData}
             />
           )}

--- a/src/test/kotlin/io/orangebuffalo/aionify/timelogs/TimeLogsDailyGoalProgressTest.kt
+++ b/src/test/kotlin/io/orangebuffalo/aionify/timelogs/TimeLogsDailyGoalProgressTest.kt
@@ -104,9 +104,35 @@ class TimeLogsDailyGoalProgressTest : TimeLogsPageTestBase() {
         page.clock().runFor(1000)
         val tooltip = page.locator("[data-testid='daily-goal-progress-tooltip']")
         assertThat(tooltip).isVisible()
-        assertThat(tooltip).containsText("Goal achievement: 100%")
         assertThat(tooltip).containsText("Daily goal met")
+        assertThat(tooltip).not().containsText("Goal achievement")
         assertThat(tooltip).not().containsText("Estimated completion")
+    }
+
+    @Test
+    fun `should not render daily goal progress for non-today entries when enabled`() {
+        val baseTime = setBaseTime("2024-03-16", "11:30")
+        val userId = requireNotNull(testUser.id)
+
+        testDatabaseSupport.insert(
+            GoalsSettings(
+                userId = userId,
+                dailyEnabled = true,
+                dailyGoalMinutes = 240,
+            ),
+        )
+        testDatabaseSupport.insert(
+            TimeLogEntry(
+                startTime = baseTime.withLocalDate("2024-03-15").withLocalTime("09:00"),
+                endTime = baseTime.withLocalDate("2024-03-15").withLocalTime("10:00"),
+                title = "Yesterday Task",
+                ownerId = userId,
+            ),
+        )
+
+        loginViaToken("/portal/time-logs", testUser, testAuthSupport)
+
+        assertThat(page.locator("[data-testid='daily-goal-progress']")).not().isVisible()
     }
 
     @Test

--- a/src/test/kotlin/io/orangebuffalo/aionify/timelogs/TimeLogsDailyGoalProgressTest.kt
+++ b/src/test/kotlin/io/orangebuffalo/aionify/timelogs/TimeLogsDailyGoalProgressTest.kt
@@ -1,0 +1,137 @@
+package io.orangebuffalo.aionify.timelogs
+
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import io.orangebuffalo.aionify.domain.DailyGoalBreak
+import io.orangebuffalo.aionify.domain.GoalsSettings
+import io.orangebuffalo.aionify.domain.TimeLogEntry
+import io.orangebuffalo.aionify.withLocalDate
+import io.orangebuffalo.aionify.withLocalTime
+import org.junit.jupiter.api.Test
+import java.time.LocalTime
+
+class TimeLogsDailyGoalProgressTest : TimeLogsPageTestBase() {
+    @Test
+    fun `should render current day daily goal progress and tooltip when enabled`() {
+        val baseTime = setBaseTime("2024-03-16", "11:30")
+        val userId = requireNotNull(testUser.id)
+
+        val goalsSettings =
+            testDatabaseSupport.insert(
+                GoalsSettings(
+                    userId = userId,
+                    dailyEnabled = true,
+                    dailyGoalMinutes = 240,
+                ),
+            )
+        testDatabaseSupport.insert(
+            DailyGoalBreak(
+                goalsSettingsId = requireNotNull(goalsSettings.id),
+                sortOrder = 0,
+                fromTime = LocalTime.of(12, 0),
+                toTime = LocalTime.of(12, 30),
+            ),
+        )
+
+        testDatabaseSupport.insert(
+            TimeLogEntry(
+                startTime = baseTime.withLocalTime("09:00"),
+                endTime = baseTime.withLocalTime("10:00"),
+                title = "Morning Task",
+                ownerId = userId,
+            ),
+        )
+        testDatabaseSupport.insert(
+            TimeLogEntry(
+                startTime = baseTime.withLocalTime("10:30"),
+                endTime = baseTime.withLocalTime("11:30"),
+                title = "Current Day Task",
+                ownerId = userId,
+            ),
+        )
+        testDatabaseSupport.insert(
+            TimeLogEntry(
+                startTime = baseTime.withLocalDate("2024-03-15").withLocalTime("09:00"),
+                endTime = baseTime.withLocalDate("2024-03-15").withLocalTime("10:00"),
+                title = "Yesterday Task",
+                ownerId = userId,
+            ),
+        )
+
+        loginViaToken("/portal/time-logs", testUser, testAuthSupport)
+
+        val progress = page.locator("[data-testid='daily-goal-progress']")
+        assertThat(progress).hasCount(1)
+        assertThat(progress).hasAttribute("aria-valuenow", "50")
+        assertThat(page.locator("[data-testid='daily-goal-progress-fill']")).hasAttribute("style", "width: 50%;")
+
+        progress.focus()
+        page.clock().runFor(1000)
+        val tooltip = page.locator("[data-testid='daily-goal-progress-tooltip']")
+        assertThat(tooltip).isVisible()
+        assertThat(tooltip).containsText("Goal achievement: 50%")
+        assertThat(tooltip).containsText("Estimated completion: 14:00")
+
+        captureUiReviewScreenshot("daily-goal-progress")
+    }
+
+    @Test
+    fun `should show daily goal met tooltip when current day total reaches goal`() {
+        val baseTime = setBaseTime("2024-03-16", "11:30")
+        val userId = requireNotNull(testUser.id)
+
+        testDatabaseSupport.insert(
+            GoalsSettings(
+                userId = userId,
+                dailyEnabled = true,
+                dailyGoalMinutes = 120,
+            ),
+        )
+        testDatabaseSupport.insert(
+            TimeLogEntry(
+                startTime = baseTime.withLocalTime("09:00"),
+                endTime = baseTime.withLocalTime("11:30"),
+                title = "Goal Met Task",
+                ownerId = userId,
+            ),
+        )
+
+        loginViaToken("/portal/time-logs", testUser, testAuthSupport)
+
+        val progress = page.locator("[data-testid='daily-goal-progress']")
+        assertThat(progress).hasAttribute("aria-valuenow", "100")
+
+        progress.focus()
+        page.clock().runFor(1000)
+        val tooltip = page.locator("[data-testid='daily-goal-progress-tooltip']")
+        assertThat(tooltip).isVisible()
+        assertThat(tooltip).containsText("Goal achievement: 100%")
+        assertThat(tooltip).containsText("Daily goal met")
+        assertThat(tooltip).not().containsText("Estimated completion")
+    }
+
+    @Test
+    fun `should not render daily goal progress when disabled`() {
+        val baseTime = setBaseTime("2024-03-16", "11:30")
+        val userId = requireNotNull(testUser.id)
+
+        testDatabaseSupport.insert(
+            GoalsSettings(
+                userId = userId,
+                dailyEnabled = false,
+                dailyGoalMinutes = 240,
+            ),
+        )
+        testDatabaseSupport.insert(
+            TimeLogEntry(
+                startTime = baseTime.withLocalTime("09:00"),
+                endTime = baseTime.withLocalTime("10:00"),
+                title = "Morning Task",
+                ownerId = userId,
+            ),
+        )
+
+        loginViaToken("/portal/time-logs", testUser, testAuthSupport)
+
+        assertThat(page.locator("[data-testid='daily-goal-progress']")).not().isVisible()
+    }
+}


### PR DESCRIPTION
## Summary

- Add current-day daily goal progress visualization to the time logs view.
- Show goal achievement and estimated completion in the progress tooltip until the goal is met.
- Show a dedicated daily-goal-met tooltip state once the goal is achieved.
- Add frontend calculation tests and full-stack Playwright coverage for enabled, disabled, met, and non-today states.
