### PR TITLE
build: migrate to Java 25 and Micronaut 5

### DIFF
--- a/.agents/skills/aionify-release/SKILL.md
+++ b/.agents/skills/aionify-release/SKILL.md
@@ -4,7 +4,7 @@ description: >
   Creates an Aionify release locally: verifies GitHub CLI and git state,
   runs the Gradle semver release task, generates JReleaser-style notes, pushes
   the release tag, and creates a draft GitHub release.
-compatibility: "requires: gh CLI, git, Java 21, Gradle wrapper"
+compatibility: "requires: gh CLI, git, Java 25, Gradle wrapper"
 ---
 
 # Aionify Release Skill

--- a/.github/actions/setup-environment/action.yml
+++ b/.github/actions/setup-environment/action.yml
@@ -1,13 +1,13 @@
 name: 'Setup Environment'
-description: 'Sets up Java 21, Gradle with caching, and Bun for building the project'
+description: 'Sets up Java 25, Gradle with caching, and Bun for building the project'
 
 runs:
   using: 'composite'
   steps:
-    - name: Set up Java 21
+    - name: Set up Java 25
       uses: actions/setup-java@v4
       with:
-        java-version: '21'
+        java-version: '25'
         distribution: 'temurin'
 
     - name: Setup Gradle

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,8 +4,8 @@ plugins {
     kotlin("jvm") version "2.4.0"
     kotlin("plugin.allopen") version "2.4.0"
     id("com.google.devtools.ksp") version "2.3.8"
-    id("io.micronaut.application") version "4.6.2"
-    id("io.micronaut.docker") version "4.6.2"
+    id("io.micronaut.application") version "5.0.2"
+    id("io.micronaut.docker") version "5.0.2"
     id("org.jlleitschuh.gradle.ktlint") version "14.2.0"
     id("com.github.jmongard.git-semver-plugin") version "0.19.2"
 }
@@ -62,6 +62,7 @@ dependencies {
     // OpenAPI / Swagger
     implementation("io.micronaut.openapi:micronaut-openapi")
     ksp("io.micronaut.openapi:micronaut-openapi")
+    implementation("tools.jackson.dataformat:jackson-dataformat-yaml")
 
     // Logging
     implementation("ch.qos.logback:logback-classic")
@@ -108,8 +109,9 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(25)
+    }
 }
 
 micronaut {
@@ -169,7 +171,7 @@ allOpen {
 
 kotlin {
     compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_21
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_25
         javaParameters = true
     }
 }

--- a/frontend/src/components/settings/TogglImportPanel.tsx
+++ b/frontend/src/components/settings/TogglImportPanel.tsx
@@ -47,10 +47,7 @@ export function TogglImportPanel() {
       // Create multipart form data
       const formData = new FormData();
       formData.append("file", new Blob([fileContent], { type: "text/csv" }), selectedFile.name);
-      formData.append(
-        "metadata",
-        new Blob([JSON.stringify({ timezone: userTimezone || "UTC" })], { type: "application/json" })
-      );
+      formData.append("timezone", userTimezone || "UTC");
 
       // Use fetch directly for multipart
       const token = localStorage.getItem("aionify_token");

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-micronautVersion=4.10.3
+micronautVersion=5.0.5
 
 # Gradle JVM arguments for build performance and stability
 # These settings prevent GC thrashing during KSP annotation processing and parallel test execution

--- a/src/main/kotlin/io/orangebuffalo/aionify/api/OpenApiSchemaController.kt
+++ b/src/main/kotlin/io/orangebuffalo/aionify/api/OpenApiSchemaController.kt
@@ -8,8 +8,7 @@ import io.micronaut.security.annotation.Secured
 import io.micronaut.security.rules.SecurityRule
 import io.swagger.v3.oas.annotations.Hidden
 import io.swagger.v3.oas.models.OpenAPI
-import org.yaml.snakeyaml.Yaml
-import java.io.InputStreamReader
+import tools.jackson.dataformat.yaml.YAMLMapper
 
 /**
  * Serves the OpenAPI schema for the public API.
@@ -27,13 +26,13 @@ open class OpenApiSchemaController(
             Thread
                 .currentThread()
                 .contextClassLoader
-                .getResourceAsStream("META-INF/swagger/aionify-1.0.0.yml")
+                .getResourceAsStream("META-INF/swagger/service-1.0.0.yml")
                 ?: return HttpResponse.notFound()
 
-        val yaml = Yaml()
+        val yamlMapper = YAMLMapper()
 
         @Suppress("UNCHECKED_CAST")
-        val schema = yaml.load<MutableMap<String, Any>>(InputStreamReader(inputStream))
+        val schema = yamlMapper.readValue(inputStream, MutableMap::class.java) as MutableMap<String, Any>
 
         // Merge custom OpenAPI configuration
         if (openApiConfig.info != null) {
@@ -63,7 +62,7 @@ open class OpenApiSchemaController(
             }
         }
 
-        val content = yaml.dump(schema)
+        val content = yamlMapper.writeValueAsString(schema)
         return HttpResponse.ok(content).contentType(MediaType.TEXT_PLAIN_TYPE)
     }
 }

--- a/src/main/kotlin/io/orangebuffalo/aionify/domain/ImportResource.kt
+++ b/src/main/kotlin/io/orangebuffalo/aionify/domain/ImportResource.kt
@@ -34,7 +34,7 @@ open class ImportResource(
     @Consumes(MediaType.MULTIPART_FORM_DATA)
     open fun importTogglCsv(
         @io.micronaut.http.annotation.Part("file") csvContent: String,
-        @io.micronaut.http.annotation.Part("metadata") metadata: ImportMetadata,
+        @io.micronaut.http.annotation.Part("timezone") timezone: String?,
         currentUser: UserWithId,
     ): HttpResponse<*> {
         log.debug("Starting Toggl import for user: {}", currentUser.user.userName)
@@ -46,9 +46,9 @@ open class ImportResource(
             // Use browser timezone if provided, otherwise fallback to UTC
             val userZoneId =
                 try {
-                    ZoneId.of(metadata.timezone ?: "UTC")
+                    ZoneId.of(timezone ?: "UTC")
                 } catch (e: Exception) {
-                    log.warn("Invalid timezone provided: {}, using UTC", metadata.timezone)
+                    log.warn("Invalid timezone provided: {}, using UTC", timezone)
                     ZoneId.of("UTC")
                 }
 
@@ -232,12 +232,6 @@ class InvalidCsvFormatException(
     message: String,
     cause: Throwable? = null,
 ) : Exception(message, cause)
-
-@Serdeable
-@Introspected
-data class ImportMetadata(
-    val timezone: String?,
-)
 
 @Serdeable
 @Introspected

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,10 +57,10 @@ flyway:
       enabled: true
 
 jackson:
-  serialization:
+  serialization-features:
     writeDatesAsTimestamps: false
-  deserialization:
-    adjust-dates-to-context-time-zone: false
+  deserialization-features:
+    adjustDatesToContextTimeZone: false
   serialization-inclusion: non-absent
 
 aionify:

--- a/src/test/kotlin/io/orangebuffalo/aionify/api/TimeLogEntryApiResourceTest.kt
+++ b/src/test/kotlin/io/orangebuffalo/aionify/api/TimeLogEntryApiResourceTest.kt
@@ -1,5 +1,6 @@
 package io.orangebuffalo.aionify.api
 
+import io.micronaut.http.HttpMethod
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.HttpStatus
 import io.micronaut.http.client.HttpClient
@@ -391,7 +392,7 @@ class TimeLogEntryApiResourceTest {
             // When: Stopping the entry
             val request =
                 HttpRequest
-                    .POST<Any>("/api/time-log-entries/stop", null)
+                    .create<Any>(HttpMethod.POST, "/api/time-log-entries/stop")
                     .bearerAuth(validToken1)
 
             val response = client.toBlocking().exchange(request, StopTimeLogEntryResponse::class.java)
@@ -415,7 +416,7 @@ class TimeLogEntryApiResourceTest {
             // When: Stopping (no active entry exists)
             val request =
                 HttpRequest
-                    .POST<Any>("/api/time-log-entries/stop", null)
+                    .create<Any>(HttpMethod.POST, "/api/time-log-entries/stop")
                     .bearerAuth(validToken1)
 
             val response = client.toBlocking().exchange(request, StopTimeLogEntryResponse::class.java)
@@ -428,7 +429,7 @@ class TimeLogEntryApiResourceTest {
         @Test
         fun `should reject request without authentication`() {
             // When: Stopping without token
-            val request = HttpRequest.POST<Any>("/api/time-log-entries/stop", null)
+            val request = HttpRequest.create<Any>(HttpMethod.POST, "/api/time-log-entries/stop")
 
             val exception =
                 assertThrows(HttpClientResponseException::class.java) {
@@ -464,7 +465,7 @@ class TimeLogEntryApiResourceTest {
             // When: User1 stops their entry
             val request =
                 HttpRequest
-                    .POST<Any>("/api/time-log-entries/stop", null)
+                    .create<Any>(HttpMethod.POST, "/api/time-log-entries/stop")
                     .bearerAuth(validToken1)
 
             client.toBlocking().exchange(request, StopTimeLogEntryResponse::class.java)

--- a/src/test/kotlin/io/orangebuffalo/aionify/timelogs/TimeLogsAutomaticUpdateTest.kt
+++ b/src/test/kotlin/io/orangebuffalo/aionify/timelogs/TimeLogsAutomaticUpdateTest.kt
@@ -1,6 +1,7 @@
 package io.orangebuffalo.aionify.timelogs
 
 import com.microsoft.playwright.Page
+import io.micronaut.http.HttpMethod
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
@@ -146,7 +147,7 @@ class TimeLogsAutomaticUpdateTest : TimeLogsPageTestBase() {
         // When: Stop the entry via public API
         val request =
             HttpRequest
-                .POST<Any>("/api/time-log-entries/stop", null)
+                .create<Any>(HttpMethod.POST, "/api/time-log-entries/stop")
                 .bearerAuth(apiToken)
 
         val response = httpClient.toBlocking().exchange(request, Map::class.java)

--- a/src/test/kotlin/io/orangebuffalo/aionify/timelogs/TimeLogsBrowserTitleTest.kt
+++ b/src/test/kotlin/io/orangebuffalo/aionify/timelogs/TimeLogsBrowserTitleTest.kt
@@ -1,6 +1,7 @@
 package io.orangebuffalo.aionify.timelogs
 
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import io.micronaut.http.HttpMethod
 import io.micronaut.http.HttpRequest
 import io.micronaut.http.client.HttpClient
 import io.micronaut.http.client.annotation.Client
@@ -89,7 +90,7 @@ class TimeLogsBrowserTitleTest : TimeLogsPageTestBase() {
         // When: Stop the entry via public API
         val stopRequest =
             HttpRequest
-                .POST<Any>("/api/time-log-entries/stop", null)
+                .create<Any>(HttpMethod.POST, "/api/time-log-entries/stop")
                 .bearerAuth(apiToken)
 
         val stopResponse = httpClient.toBlocking().exchange(stopRequest, Map::class.java)


### PR DESCRIPTION
## Summary
- migrate the build, CI, and release workflow to Java 25
- upgrade to Micronaut 5.0.5 and Gradle plugins 5.0.2
- adapt Jackson YAML, OpenAPI schema loading, multipart import binding, and null-safe HTTP tests for Micronaut 5

## Verification
- `./gradlew format test --tests "io.orangebuffalo.aionify.api.ApiAuthenticationTest" --tests "io.orangebuffalo.aionify.TogglImportValidationPlaywrightTest" --console=plain`
- `./gradlew build --console=plain`